### PR TITLE
feat: add iterable dataset support to GRPOTrainer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ soundfile
 jiwer
 wandb
 backoff
+more-itertools

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires =
     accelerate>=1.4.0
     datasets>=3.0.0
     transformers>=4.51.3
+    more-itertools
 
 [options.packages.find]
 exclude =

--- a/tests/test_grpo_trainer.py
+++ b/tests/test_grpo_trainer.py
@@ -254,6 +254,28 @@ class GRPOTrainerTester(unittest.TestCase):
                 new_param = trainer.model.get_parameter(n)
                 self.assertFalse(torch.equal(param, new_param), f"Parameter {n} has not changed.")
 
+    def test_training_with_iterable_dataset(self):
+        dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train").to_iterable_dataset()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            training_args = GRPOConfig(
+                output_dir=tmp_dir,
+                learning_rate=0.1,
+                per_device_train_batch_size=3,
+                num_generations=3,
+                max_completion_length=8,
+                report_to="none",
+                max_steps=1,
+            )
+            trainer = GRPOTrainer(
+                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                reward_funcs="trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
+                args=training_args,
+                train_dataset=dataset,
+            )
+
+            trainer.train()
+
     @parameterized.expand([("bnpo",), ("dr_grpo",)])
     def test_training_loss_types(self, loss_type):
         dataset = load_dataset("trl-internal-testing/zen", "standard_prompt_only", split="train")


### PR DESCRIPTION
## Summary
- support iterable datasets in GRPOTrainer via `RepeatIterableDataset`
- handle iterable datasets and unknown-length dataloaders in evaluation loop
- add regression test covering iterable dataset training
- factor dataset wrapping helper and simplify train sampler
- inline training sampler and update related comments
- rely on `more-itertools` for `chunked` and `unique_everseen`

## Testing
- `pre-commit run --files requirements.txt setup.cfg trl/trainer/grpo_trainer.py tests/test_grpo_trainer.py` *(command not found: pre-commit)*
- `pip install pre-commit` *(Tunnel connection failed: 403 Forbidden)*
- `pytest tests/test_grpo_trainer.py -k test_training_with_iterable_dataset -q` *(ModuleNotFoundError: No module named 'parameterized')*
- `pip install parameterized` *(Tunnel connection failed: 403 Forbidden)*
- `PYTHONPATH=. python trl/scripts/grpo_bias.py --config orng_conf/biasing/grpo_bias_vllm_colocate_debug_local.yaml` *(ModuleNotFoundError: No module named 'more_itertools')*
- `pip install more-itertools` *(Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68967f747c8c832891ea7e83d7626a0a